### PR TITLE
UG-992: Build server-side component

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
 	"presets": [
-    [ "@babel/preset-env" ],
+    [ "@babel/preset-env", { "targets": "defaults"} ],
 		[ "preact" ]
   ],
   "plugins": ["@babel/plugin-syntax-jsx"]

--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -18,8 +18,6 @@ hooks:
     - WebpackDevelopment
 
 options:
-  '@dotcom-tool-kit/webpack':
-    configPath: demos/webpack.config.js
   '@dotcom-tool-kit/prettier':
     files: ['{,!(node_modules|demos/public)/**/}*.js']
   '@dotcom-tool-kit/eslint':

--- a/BrowsableListsData.jsx
+++ b/BrowsableListsData.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DataEmbed } from '@financial-times/dotcom-ui-data-embed';
+import { DataEmbed } from '@financial-times/dotcom-ui-data-embed/dist/node';
 // eslint-disable-next-line no-unused-vars
 import { h } from '@financial-times/x-engine';
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Import the styles into consumer's `main.scss`
 Import the client-side code into the consumer's `main.js` and initialised it, passing it the parent's selector as argument
 
 ```
-const { init: browsableListsInit } = require('../../main.js');
+import { init as browsableListsInit } from '@financial-times/n-browsable-lists';
 
 browsableListsInit({
 	parentSelector: '.rhr'

--- a/demos/templates/main.jsx
+++ b/demos/templates/main.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Shell } from '@financial-times/dotcom-ui-shell';
-import { BrowsableLists } from '../..';
+import { BrowsableLists } from '../../';
 
 const concepts = [
 	'24ad2c58-14fb-4217-b6f7-7ef88ac51375'

--- a/demos/webpack.config.js
+++ b/demos/webpack.config.js
@@ -24,7 +24,8 @@ module.exports = {
 						presets: [
 							['@babel/preset-env', { targets: 'defaults' }],
 							['preact']
-						]
+						],
+						plugins: ['@babel/plugin-syntax-jsx']
 					}
 				}
 			}

--- a/main.js
+++ b/main.js
@@ -23,6 +23,10 @@ export async function init({ parentSelector }) {
 
 		const listId = matchedList?.listId;
 
+		if (!listId) {
+			return;
+		}
+
 		try {
 			const listData = await myftClient
 				.init()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@financial-times/dotcom-ui-data-embed": "^7.1.4",
         "@financial-times/n-concept-ids": "^1.21.0",
         "@financial-times/x-engine": "^8.1.0",
         "next-myft-client": "^10.4.0",
-        "react-dom": "^16.14.0"
+        "prop-types": "^15.8.1"
       },
       "devDependencies": {
         "@babel/core": "^7.19.1",
@@ -38,13 +39,13 @@
         "eslint-plugin-react": "^7.31.8",
         "express": "^4.18.1",
         "express-http-proxy": "^1.6.3",
-        "install": "^0.13.0",
         "nodemon": "^2.0.20",
         "npm": "^8.19.2",
         "preact": "^8.5.3",
         "preact-render-to-string": "^4.1.0",
         "react": "^16.14.0",
-        "sucrase": "^3.27.0"
+        "sucrase": "^3.27.0",
+        "webpack-node-externals": "^3.0.0"
       },
       "peerDependencies": {
         "@financial-times/o-colors": "^6.4.2",
@@ -2116,10 +2117,9 @@
       }
     },
     "node_modules/@financial-times/dotcom-ui-data-embed": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/dotcom-ui-data-embed/-/dotcom-ui-data-embed-7.1.1.tgz",
-      "integrity": "sha512-zzLUYbKyxsChSf7djHkhRtdU5aLqNx1VtmGnW0fn9TxB+zXogpL26U6+7kxydXAhHI+NSY/spOgue0qqvdewuQ==",
-      "dev": true,
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/dotcom-ui-data-embed/-/dotcom-ui-data-embed-7.1.4.tgz",
+      "integrity": "sha512-PTkQ/Rac1rZVl531MvyoGohx/UBj0xg/giFN+G6L7EHCO4/vHV+OO7s9H+xJmpBpMJRT/0/PoS29pGcTVuKhYQ==",
       "hasInstallScript": true,
       "engines": {
         "node": ">= 14.0.0",
@@ -7783,15 +7783,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "node_modules/install": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
-      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -14355,6 +14346,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -14924,6 +14916,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -17559,6 +17552,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/webpack-node-externals": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
+      "integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -19546,10 +19548,9 @@
       }
     },
     "@financial-times/dotcom-ui-data-embed": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/dotcom-ui-data-embed/-/dotcom-ui-data-embed-7.1.1.tgz",
-      "integrity": "sha512-zzLUYbKyxsChSf7djHkhRtdU5aLqNx1VtmGnW0fn9TxB+zXogpL26U6+7kxydXAhHI+NSY/spOgue0qqvdewuQ==",
-      "dev": true,
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/dotcom-ui-data-embed/-/dotcom-ui-data-embed-7.1.4.tgz",
+      "integrity": "sha512-PTkQ/Rac1rZVl531MvyoGohx/UBj0xg/giFN+G6L7EHCO4/vHV+OO7s9H+xJmpBpMJRT/0/PoS29pGcTVuKhYQ==",
       "requires": {}
     },
     "@financial-times/dotcom-ui-flags": {
@@ -24086,12 +24087,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "install": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
-      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
       "dev": true
     },
     "internal-slot": {
@@ -29102,6 +29097,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -29525,6 +29521,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -31921,6 +31918,12 @@
         "clone-deep": "^4.0.1",
         "wildcard": "^2.0.0"
       }
+    },
+    "webpack-node-externals": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
+      "integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+      "dev": true
     },
     "webpack-sources": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "@financial-times/n-browsable-lists",
   "version": "0.0.0",
   "description": "A front-end component to show a panel with browsable lists for a topic",
-  "main": "index.jsx",
+  "main": "dist/component.js",
+  "browser": "main.js",
+  "files": [
+    "main.js",
+    "main.scss",
+    "concept-list-map.js",
+    "BrowsableListContent.jsx",
+    "dist/component.js"
+  ],
   "scripts": {
     "test": "dotcom-tool-kit test:local",
     "format": "dotcom-tool-kit format:local",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "dotcom-tool-kit format:local",
     "build": "dotcom-tool-kit build:local",
     "start": "dotcom-tool-kit run:local",
-    "demo": "./demos/make-certs.sh && concurrently -n webpack,node \"npm run start\" \"nodemon -e js,mjs,json,jsx demos/start.js\"",
+    "demo": "./demos/make-certs.sh && concurrently -n webpack,node \"webpack --config demos/webpack.config.js --watch\" \"nodemon -e js,mjs,json,jsx demos/start.js\"",
     "heroku-postbuild": "dotcom-tool-kit build:remote release:remote cleanup:remote"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "eslint-plugin-react": "^7.31.8",
     "express": "^4.18.1",
     "express-http-proxy": "^1.6.3",
-    "install": "^0.13.0",
     "nodemon": "^2.0.20",
     "npm": "^8.19.2",
     "preact": "^8.5.3",
     "preact-render-to-string": "^4.1.0",
     "react": "^16.14.0",
-    "sucrase": "^3.27.0"
+    "sucrase": "^3.27.0",
+    "webpack-node-externals": "^3.0.0"
   },
   "husky": {
     "hooks": {
@@ -63,10 +63,11 @@
     "**/*.js": "dotcom-tool-kit format:staged test:staged --"
   },
   "dependencies": {
+    "@financial-times/dotcom-ui-data-embed": "^7.1.4",
     "@financial-times/n-concept-ids": "^1.21.0",
     "@financial-times/x-engine": "^8.1.0",
     "next-myft-client": "^10.4.0",
-    "react-dom": "^16.14.0"
+    "prop-types": "^15.8.1"
   },
   "peerDependencies": {
     "@financial-times/o-colors": "^6.4.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,39 @@
+const xEngine = require('@financial-times/x-engine/src/webpack');
+const { PageKitSassPlugin } = require('@financial-times/dotcom-build-sass');
+const nodeExternals = require('webpack-node-externals');
+
+const plugins = [new PageKitSassPlugin(), xEngine()];
+
+module.exports = {
+	mode: 'production',
+	entry: {
+		component: './index.jsx'
+	},
+	module: {
+		rules: [
+			{
+				test: /\.jsx?$/,
+				exclude: /(node_modules)/,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							['@babel/preset-env', { targets: 'defaults' }],
+							['preact']
+						],
+						plugins: ['@babel/plugin-syntax-jsx']
+					}
+				}
+			}
+		]
+	},
+	plugins,
+	output: {
+		globalObject: 'this',
+		path: __dirname + '/dist/',
+		filename: 'component.js',
+		libraryTarget: 'umd'
+	},
+	target: 'node',
+	externals: [nodeExternals()]
+};


### PR DESCRIPTION
### Description

Consumer apps need to use a transpiled version of the server-side component of this library. These changes include:
- Adding a build step for the server-side component (`BrowsableListsData`).
- Defining the exported files using the `files` property on `package.json`.
- Defining the `browser` (client-side) and `main` (server-side) entry points to consume this app.
- Updating the `npm run demo` script.

### Ticket
[UG-992](https://financialtimes.atlassian.net/browse/UG-992)

### How do I test this code?
- Check out this branch.
- Run `npm run build` the server-side component. Run `npm link` to create a symlink to this component.
- Check out the `ug-992-browsable-lists` branch on `next-article`.
- Run `npm link @financial-times/n-browsable-lists` to consume the component's symlink.
- Run `npm run build` and `npm start`
- Switch on [myftBrowsableLists](https://toggler.ft.com/#myftBrowsableLists) flag on FT Toggler
- Go to an article from `Climate Change` topic, like [this one](https://local.ft.com:5050/content/c7ea1893-75a4-4fa2-b524-aa5df625ee91), and confirm that the browsable lists component is shown

### Reminder
Have you completed these common tasks? (remove those that don't apply)

- [x] **Manual Testing** checked the expected functionality
- [x] **Guidance for reviewer** communicated expected changes / behaviour, and how reviewers can test it


### How we will review this PR
Our team uses [conventional comments](https://conventionalcomments.org/) to provide feedback.
