### PR TITLE
fix typo in file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "main.js",
     "main.scss",
     "concept-list-map.js",
-    "BrowsableListContent.jsx",
+    "BrowsableListsContent.jsx",
     "dist/component.js"
   ],
   "scripts": {


### PR DESCRIPTION
We're missing an 's' so that means BrowsableListsContent.jsx is not being published to npm.
