### PR TITLE
UG-1089 Make heading variable 

### DIFF
--- a/BrowsableListsContent.jsx
+++ b/BrowsableListsContent.jsx
@@ -4,14 +4,15 @@ import PropTypes from 'prop-types';
 import { h } from '@financial-times/x-engine';
 
 BrowsableListsContent.propTypes = {
+  heading: PropTypes.string.isRequired,
   listData: PropTypes.object.isRequired,
 };
 
-export function BrowsableListsContent ({ listData }) {
+export function BrowsableListsContent ({ heading, listData }) {
 	if (listData?.articleData?.length > 0) {
 		return (
 			<div className='browsable-lists'>
-				<h2 className='browsable-lists-heading'>Curated list by a university professor</h2>
+				<h2 className='browsable-lists-heading'>{heading}</h2>
 				<div className='browsable-lists-title'>
 					<a href={`https://www.ft.com/myft/list/${listData.id}`} data-trackable="browsable-list-heading"><h3 className='browsable-lists-title-heading'>{listData.name}</h3></a>
 					<p className='browsable-lists-title-text'>{listData.articleData.length} Saved articles</p>

--- a/demos/app.js
+++ b/demos/app.js
@@ -12,8 +12,13 @@ app.set('view engine', 'html');
 const renderer = new PageKitReactJSX();
 app.engine('jsx', renderer.engine);
 
-app.get('/', (req, res) => {
-	return res.render('main.jsx', { layout: 'custom-vanilla', title: 'Demo' });
+app.get('/:conceptId?', (req, res) => {
+	const { conceptId } = req.params;
+	return res.render('main.jsx', {
+		layout: 'custom-vanilla',
+		title: 'Demo',
+		conceptId
+	});
 });
 
 app.all('/__myft/*', proxy('https://www.ft.com/__myft/'));

--- a/demos/templates/main.jsx
+++ b/demos/templates/main.jsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import { Shell } from '@financial-times/dotcom-ui-shell';
+import PropTypes from 'prop-types';
 import { BrowsableLists } from '../../';
 
-const concepts = [
-	'48256173-6393-4d0e-9364-19a52aef5df1'
-]
+const DEFAULT_CONCEPT = '48256173-6393-4d0e-9364-19a52aef5df1'
 
-export default function MainTemplate() {
+MainTemplate.propTypes = {
+	conceptId: PropTypes.string,
+};
+
+export default function MainTemplate({ conceptId = DEFAULT_CONCEPT }) {
+	const concepts = [
+		conceptId
+	]
+
 	return (
 		<Shell siteTitle={`Browsable lists demo`}>
 			<link rel="stylesheet" href="./public/styles.css"/>

--- a/main.js
+++ b/main.js
@@ -8,6 +8,17 @@ import { BrowsableListsContent } from './BrowsableListsContent.jsx';
 // eslint-disable-next-line no-unused-vars
 import { h, render } from '@financial-times/x-engine';
 
+function getHeadingBySource(source) {
+	switch (source) {
+		case sources.EDITORIAL:
+			return 'Curated list by FT Editorial';
+		case sources.PROFESSOR:
+			return 'Curated list by a university professor';
+		default:
+			return 'Curated list';
+	}
+}
+
 export async function init({ parentSelector }) {
 	const dataEmbedClient = dataEmbed.init({ id: 'browsable-lists-data' });
 
@@ -32,7 +43,13 @@ export async function init({ parentSelector }) {
 				.init()
 				.then(() => myftClient.getPublicList(listId));
 
-			render(<BrowsableListsContent listData={listData} />, container);
+			render(
+				<BrowsableListsContent
+					listData={listData}
+					heading={getHeadingBySource(matchedList.source)}
+				/>,
+				container
+			);
 		} catch {
 			// Do not render the component if the request failed
 		}

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ import React from 'react';
 import * as dataEmbed from '@financial-times/dotcom-ui-data-embed';
 import myftClient from 'next-myft-client';
 
-import { conceptListMap } from './concept-list-map';
+import { conceptListMap, sources } from './concept-list-map';
 import { BrowsableListsContent } from './BrowsableListsContent.jsx';
 
 // eslint-disable-next-line no-unused-vars

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ import { h, render } from '@financial-times/x-engine';
 function getHeadingBySource(source) {
 	switch (source) {
 		case sources.EDITORIAL:
-			return 'Curated list by FT Editorial';
+			return 'Curated list by the Financial Times';
 		case sources.PROFESSOR:
 			return 'Curated list by a university professor';
 		default:


### PR DESCRIPTION
### Description

This PR changes the heading to show the list source. e.g.: `Curated list by {source}`

- Adds a new property `source` to the concept/list mapping object. 
- Adds a new method `getHeadingBySource` to return the heading text according to the source
- Replaces the hardcoded headline for the `heading` property

### Ticket
[UG-1089](https://financialtimes.atlassian.net/browse/UG-1089)


### Screenshots

| Professor | FT Editorial |
| ------ | ----- |
|<img width="309" alt="list created by university professor" src="https://user-images.githubusercontent.com/7011304/205693238-050f178f-8cbd-46d2-9854-f30f3ef99c5b.png">|<img width="308" alt="list created by FT editoria" src="https://user-images.githubusercontent.com/7011304/205693208-ef388118-e449-42f1-9bb3-65466ff1643b.png">|

### How do I test this code?

- Check out this branch locally
- Run the demo page with `npm run demo`
- Go to the demo page for the [topic technology](https://local.ft.com:5005/6b32f2c1-da43-4e19-80b9-8aef4ab640d7) and confirm that the heading is `Curated list by FT Editorial`

### Reminder
Have you completed these common tasks? (remove those that don't apply)

- [x] **Manual Testing** checked the expected functionality
- [x] **Guidance for reviewer** communicated expected changes / behaviour, and how reviewers can test it
- [x] **Accessibility** checked for screen readers and contrast
- [x] **Design Review** ran past the designer 
- [x] **Product Review** ran past the product owner


### How we will review this PR
Our team uses [conventional comments](https://conventionalcomments.org/) to provide feedback.
