### PR TITLE
Ug-1016 update static mappings

### DIFF
--- a/concept-list-map.js
+++ b/concept-list-map.js
@@ -1,52 +1,247 @@
-import { topic } from '@financial-times/n-concept-ids';
+export const sources = {
+	EDITORIAL: 'editorial',
+	PROFESSOR: 'university professor'
+};
+
+const covidList = {
+	id: '3730c9e4-d2d5-4dd0-9e77-59d6121a9869',
+	source: sources.EDITORIAL
+};
+
+const ukraineList = {
+	id: '100fa2f1-8c59-4aaf-90e9-69e383f4d2ef',
+	source: sources.EDITORIAL
+};
+
+const twitterList = {
+	id: '8a295234-041e-4924-a73d-effd317bd737',
+	source: sources.EDITORIAL
+};
+
+const cryptoList = {
+	id: '44a24834-eae9-4fe4-9eeb-b28c511579b1',
+	source: sources.EDITORIAL
+};
+
+const usPoliticsList = {
+	id: '9395c85b-0bd6-407b-b6a4-1d350f4d5060',
+	source: sources.EDITORIAL
+};
+
+const usInflationList = {
+	id: 'd82b88d2-c6e6-47eb-b884-b621249857b1',
+	source: sources.EDITORIAL
+};
+
+const lifeArtsList = {
+	id: 'e90439da-a541-4c14-88c8-707fcea6d84e',
+	source: sources.EDITORIAL
+};
 
 export const conceptListMap = [
 	{
-		conceptId: topic.socialAndEnvironmentalImpactInvestment,
-		listId: '2dc928f3-766f-48c5-92d9-8f75ad55d497'
+		conceptId: '48256173-6393-4d0e-9364-19a52aef5df1',
+		listId: covidList.id,
+		source: covidList.source
 	},
 	{
-		conceptId: topic.equities,
-		listId: '6dc246b1-d828-4674-81e0-f5da51b63ac0'
+		conceptId: 'f1a6c14e-1fb0-4f7f-83a0-552276dc6cfb',
+		listId: covidList.id,
+		source: covidList.source
 	},
 	{
-		conceptId: topic.chinaTrade,
-		listId: '1ccb2993-aaa9-4d0e-af98-19001eccc5b6'
+		conceptId: '87e110e6-2170-408b-b267-d3b6bdbfeaa3',
+		listId: covidList.id,
+		source: covidList.source
 	},
 	{
-		conceptId: topic.technology,
-		listId: '0d6833ae-3b00-4b28-8bc8-dd410c0e083b'
+		conceptId: '8b9c78a1-2a6d-4e2f-9293-49f399f4f6ce',
+		listId: ukraineList.id,
+		source: ukraineList.source
 	},
 	{
-		conceptId: topic.americasPoliticsPolicy,
-		listId: '71a6293e-374f-4dc7-8cc9-f1ab65578b74'
+		conceptId: 'db09717e-0073-4283-93a1-c2f0c0d8a4dc',
+		listId: ukraineList.id,
+		source: ukraineList.source
 	},
 	{
-		conceptId: topic.globalTrade,
-		listId: '8a7d6bc9-6382-43ad-a232-eacd2168ffe9'
+		conceptId: '573cc1d3-b359-4548-a69a-4aa0b3818c1b',
+		listId: ukraineList.id,
+		source: ukraineList.source
 	},
 	{
-		conceptId: topic.ukEnergy,
-		listId: '0f7aac3e-d8f4-46ab-9bb7-bbb1b1975b3c'
+		conceptId: 'f25f84dd-a570-468f-b370-e314e96fc319',
+		listId: ukraineList.id,
+		source: ukraineList.source
 	},
 	{
-		conceptId: topic.climateChange,
-		listId: 'bc1c632a-f2e9-4d98-a8e6-900c235d7b0a'
+		conceptId: '5216ff2e-a6ed-42b2-a613-109fc6491ba2',
+		listId: ukraineList.id,
+		source: ukraineList.source
 	},
 	{
-		conceptId: topic.cryptocurrencies,
-		listId: 'b564e2c2-40f1-4d00-b3cf-6fdacbf9ab6c'
+		conceptId: '68678217-1d06-4600-9d43-b0e71a333c2a',
+		listId: ukraineList.id,
+		source: ukraineList.source
 	},
 	{
-		conceptId: topic.warInUkraine,
-		listId: '6164a607-9b2d-4579-93fe-7e3d9c2cbc44'
+		conceptId: '29e67a92-a3b8-410c-9139-15abe9b47e12',
+		listId: ukraineList.id,
+		source: ukraineList.source
 	},
 	{
-		conceptId: topic.lifeArts,
-		listId: 'ed0c2ff2-d2e7-4825-8f8c-86e448b0aa08'
+		conceptId: '9ab8e36c-4b79-4e96-9aae-cc586b7d19c4',
+		listId: ukraineList.id,
+		source: ukraineList.source
 	},
 	{
-		conceptId: topic.coronavirus,
-		listId: 'a63f6ee0-0273-451c-9172-9f4164aac7bf'
+		conceptId: 'a54ba68e-4aa3-4aa0-8a11-61456f4dfaa1',
+		listId: twitterList.id,
+		source: twitterList.source
+	},
+	{
+		conceptId: '6b32f2c1-da43-4e19-80b9-8aef4ab640d7',
+		listId: twitterList.id,
+		source: twitterList.source
+	},
+	{
+		conceptId: 'fdf71598-69ee-4801-a704-df53f01ef286',
+		listId: twitterList.id,
+		source: twitterList.source
+	},
+	{
+		conceptId: '03711791-2306-46a4-a5f5-1d79e57bd21d',
+		listId: twitterList.id,
+		source: twitterList.source
+	},
+	{
+		conceptId: '1248b3d3-1d4c-4454-af23-c0b4707ed412',
+		listId: twitterList.id,
+		source: twitterList.source
+	},
+	{
+		conceptId: '9d13b836-df76-4445-b599-10ae378680f0',
+		listId: twitterList.id,
+		source: twitterList.source
+	},
+	{
+		conceptId: '6c503953-7ee0-45d7-b316-f7834be9ff90',
+		listId: cryptoList.id,
+		source: cryptoList.source
+	},
+	{
+		conceptId: 'baf2d326-7e13-4309-9f87-3eb1708468ff',
+		listId: cryptoList.id,
+		source: cryptoList.source
+	},
+	{
+		conceptId: 'fb8cdc23-cd37-41b2-abe1-c4dd1fc334af',
+		listId: cryptoList.id,
+		source: cryptoList.source
+	},
+	{
+		conceptId: 'a072c32f-42de-4cc6-8e77-c468d681e5db',
+		listId: cryptoList.id,
+		source: cryptoList.source
+	},
+	{
+		conceptId: '72709ae9-1963-4d08-a153-8a5746accb20',
+		listId: cryptoList.id,
+		source: cryptoList.source
+	},
+	{
+		conceptId: '64cf47f4-3f23-4d52-9c88-c11575e57749',
+		listId: cryptoList.id,
+		source: cryptoList.source
+	},
+	{
+		conceptId: '56f3a4f4-2a28-4a03-8bcc-cabf82c4015b',
+		listId: cryptoList.id,
+		source: cryptoList.source
+	},
+	{
+		conceptId: 'e191658e-c66a-45bc-9bad-343bdc4210b3',
+		listId: usPoliticsList.id,
+		source: usPoliticsList.source
+	},
+	{
+		conceptId: 'eeb704cf-70f9-4bab-a630-576ce68a9aab',
+		listId: usPoliticsList.id,
+		source: usPoliticsList.source
+	},
+	{
+		conceptId: '6f7d5d90-ac15-41fe-9e31-e69b42a013c6',
+		listId: usPoliticsList.id,
+		source: usPoliticsList.source
+	},
+	{
+		conceptId: '9f991f8b-1d17-4d99-82f4-0cd8fe50b59b',
+		listId: usPoliticsList.id,
+		source: usPoliticsList.source
+	},
+	{
+		conceptId: '7982616a-e179-45f1-86f6-948f1fc35523',
+		listId: usInflationList.id,
+		source: usInflationList.source
+	},
+	{
+		conceptId: '9ebb1f73-1eed-4031-9c5e-bc56800abba7',
+		listId: usInflationList.id,
+		source: usInflationList.source
+	},
+	{
+		conceptId: '456d01ad-ea50-4aa7-8d7f-b9737216d453',
+		listId: usInflationList.id,
+		source: usInflationList.source
+	},
+	{
+		conceptId: '6aa143a2-7a0c-4a20-ae90-ca0a46f36f92',
+		listId: usInflationList.id,
+		source: usInflationList.source
+	},
+	{
+		conceptId: '9577c6d4-b09e-4552-b88f-e52745abe02b',
+		listId: usInflationList.id,
+		source: usInflationList.source
+	},
+	{
+		conceptId: 'e5533208-e5cc-4be5-aea1-c464a9a205e3',
+		listId: usInflationList.id,
+		source: usInflationList.source
+	},
+	{
+		conceptId: '3e2eb1c1-7ecd-4600-8cbb-c02ba53ced4b',
+		listId: usInflationList.id,
+		source: usInflationList.source
+	},
+	{
+		conceptId: '0b83bc44-4a55-4958-882e-73ba6b2b0aa6',
+		listId: lifeArtsList.id,
+		source: lifeArtsList.source
+	},
+	{
+		conceptId: 'f9f7535d-3b5c-47a7-bd15-3e10dceee597',
+		listId: lifeArtsList.id,
+		source: lifeArtsList.source
+	},
+	{
+		conceptId: 'bf588a1d-44e1-495c-93f5-a98e1e3aa8d8',
+		listId: lifeArtsList.id,
+		source: lifeArtsList.source
+	},
+	{
+		conceptId: '02d551a4-94a6-4783-8ea9-8aa982cb1225',
+		listId: lifeArtsList.id,
+		source: lifeArtsList.source
+	},
+	{
+		conceptId: '6c94a300-579e-43d0-8536-b2ae05bb6ff4',
+		listId: lifeArtsList.id,
+		source: lifeArtsList.source
+	},
+	{
+		conceptId: '0d5b6eb9-7512-4db2-ae4a-b9d4e0da548a',
+		listId: lifeArtsList.id,
+		source: lifeArtsList.source
 	}
 ];

--- a/demos/templates/main.jsx
+++ b/demos/templates/main.jsx
@@ -3,7 +3,7 @@ import { Shell } from '@financial-times/dotcom-ui-shell';
 import { BrowsableLists } from '../../';
 
 const concepts = [
-	'24ad2c58-14fb-4217-b6f7-7ef88ac51375'
+	'48256173-6393-4d0e-9364-19a52aef5df1'
 ]
 
 export default function MainTemplate() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@financial-times/dotcom-ui-data-embed": "^7.1.4",
-        "@financial-times/n-concept-ids": "^1.21.0",
         "@financial-times/o-tracking": "^4.4.0",
         "@financial-times/x-engine": "^8.1.0",
         "next-myft-client": "^10.4.0",
@@ -2212,11 +2211,6 @@
       "peerDependencies": {
         "mathsass": "0.10.1"
       }
-    },
-    "node_modules/@financial-times/n-concept-ids": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-concept-ids/-/n-concept-ids-1.21.0.tgz",
-      "integrity": "sha512-6WOo7sf90du8Kx/RlAxHZ+deh8lSsOoU1awmMIG4MPAWPkzWbwMADMlsNkNIcc4hBE03TVJ0tREbgdUniQ2BTA=="
     },
     "node_modules/@financial-times/o-brand": {
       "version": "4.2.1",
@@ -19615,11 +19609,6 @@
       "integrity": "sha512-de62A+grddYjBzOf5NogvRou2othrHThVxPKf4hWjEvTTMTisPDvVfc7jiVm3OvH7FyGImwrpPJN/u30NzeLmQ==",
       "peer": true,
       "requires": {}
-    },
-    "@financial-times/n-concept-ids": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-concept-ids/-/n-concept-ids-1.21.0.tgz",
-      "integrity": "sha512-6WOo7sf90du8Kx/RlAxHZ+deh8lSsOoU1awmMIG4MPAWPkzWbwMADMlsNkNIcc4hBE03TVJ0tREbgdUniQ2BTA=="
     },
     "@financial-times/o-brand": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   },
   "dependencies": {
     "@financial-times/dotcom-ui-data-embed": "^7.1.4",
-    "@financial-times/n-concept-ids": "^1.21.0",
     "@financial-times/x-engine": "^8.1.0",
     "@financial-times/o-tracking": "^4.4.0",
     "next-myft-client": "^10.4.0",


### PR DESCRIPTION
### Description

 Primary: Remove placeholder lists and replace with FT curated lists
 Secondary:

-  I'm removing dependence on n-concept-ids as it's missing around 30 of our concepts and hardcoding is concept IDs sufficient for the MVP

-  Adding professor property in anticipation of having 2 different types of lists, which will require different copy

### Ticket
[ug-1016](https://financialtimes.atlassian.net/browse/UG-1016)

### How do I test this code?
Quick:

Clone, install and build the branch locally, and run `npm run demo` - this should show a new list (note: still referred to as "professor" atm)

In-depth:

1. On the local branch, run `npm link`
2. In next-article, pull down the latest and checkout `ug-992-browsable-lists` 
3. In next-article, run `npm link @financial-times/n-browsable-lists` 
4. Visit local pages to see whether related lists appear, e.g. https://local.ft.com:5050/content/066ca9f0-02d2-417d-8e1d-5e04c191bb9c. 

They should appear for the following topics (list name in bold):

**Covid: the continuing fallout**
Coronavirus
Health
Coronavirus economic impact

**Ukraine: Russia’s war and its consequences**
War in Ukraine
Russian economy
Global inflation
Bank of Russia
Energy sector
Russia
Global Economy
Food security

**Twitter: Musk takes charge**
Technology sector
Twitter inc
Social Media
Elon Musk
US & Canadian companies
Mergers & Acquisitions 


**Crypto currencies: Rise and Fall**
Cryptocurrencies
Financial & markets regulation
US Securities and Exchange Commission
Bitcoin
Non-fungible tokens
Blockchain
Investments
Investing in funds

**US Politics: trends and patterns**
John Burn-Murdoch
Data Points
US politics and policy
Oil & Gas industry

**US inflation: trends, effects**
US inflation
US dollar
US banks
US economy
US interest rates
Federal Reserve
US

**Life and Arts: cultural insights and advice**
Life & Arts
Fashion
Visual Arts
Gaming
Music
Behavioural economics



