### PR TITLE
ug-995 add an event when the component loads with a list

### DIFF
--- a/BrowsableListsContent.jsx
+++ b/BrowsableListsContent.jsx
@@ -6,9 +6,23 @@ import { h } from '@financial-times/x-engine';
 BrowsableListsContent.propTypes = {
   heading: PropTypes.string.isRequired,
   listData: PropTypes.object.isRequired,
+  conceptId: PropTypes.string.isRequired
 };
 
-export function BrowsableListsContent ({ heading, listData }) {
+export function BrowsableListsContent ({ heading, listData, conceptId }) {
+
+	document.body.dispatchEvent(new CustomEvent('oTracking.event', {
+		detail: {
+			category: 'browsable-lists',
+			action: 'component-mounted',
+			teamName: 'customer-products-us-growth',
+			amplitudeExploratory: true,
+			conceptId: conceptId,
+			listId: listData.id
+		},
+		bubbles: true
+	}));	
+
 	if (listData?.articleData?.length > 0) {
 		return (
 			<div className='browsable-lists'>

--- a/main.js
+++ b/main.js
@@ -47,6 +47,7 @@ export async function init({ parentSelector }) {
 				<BrowsableListsContent
 					listData={listData}
 					heading={getHeadingBySource(matchedList.source)}
+					conceptId={matchedList.conceptId}
 				/>,
 				container
 			);


### PR DESCRIPTION
### Description
Adds a tracking event that fires when an article's concept matches a list to make it easy to analyse the conversion funnel in Amplitude. Theoretically this could fire and then there's a problem and the list ends up not being displayed, but I think this is ok for the MVP because:

- The risk of this is small
- Using a hook to fire an event after the component mounts (or even better, after it enters the viewport) is complicated by the fact that next-article uses preact client-side, but an older version that doesn't use hooks. We've spent some time investigating this but don't want to waste too much engineering time when there is a viable alternative
- This is to aid analysis only

### Ticket
[ug-995](https://financialtimes.atlassian.net/browse/UG-995)

### How do I test this code?

- Clone the branch locally, install and run `npm run demo`. 
- In the network section of dev tools, check that an `ingest` request was made with the following in the payload:
system > action: load
system > category: browsable-lists
system > context > amplitude-exploratory: true
system > context > teamName: customer-products-us-growth

