### PR TITLE
Ug-995 metrics extended

### DIFF
--- a/BrowsableListsContent.jsx
+++ b/BrowsableListsContent.jsx
@@ -5,23 +5,10 @@ import { h } from '@financial-times/x-engine';
 
 BrowsableListsContent.propTypes = {
   heading: PropTypes.string.isRequired,
-  listData: PropTypes.object.isRequired,
-  conceptId: PropTypes.string.isRequired
+  listData: PropTypes.object.isRequired
 };
 
-export function BrowsableListsContent ({ heading, listData, conceptId }) {
-
-	document.body.dispatchEvent(new CustomEvent('oTracking.event', {
-		detail: {
-			category: 'browsable-lists',
-			action: 'component-mounted',
-			teamName: 'customer-products-us-growth',
-			amplitudeExploratory: true,
-			conceptId: conceptId,
-			listId: listData.id
-		},
-		bubbles: true
-	}));	
+export function BrowsableListsContent ({ heading, listData }) {
 
 	if (listData?.articleData?.length > 0) {
 		return (

--- a/main.scss
+++ b/main.scss
@@ -16,6 +16,7 @@ $o-typography-load-fonts: false;
 	background: oColorsByName('white-40');
 	border: 1px solid oColorsByName('black-10');
 	padding: 12px;
+	margin-bottom: 20px;
 
 	&-heading {
 		@include oTypographySans($scale: -1, $weight: 'regular');


### PR DESCRIPTION
### Description
After chatting with Tash, we realised that we actually need some more metrics so that we can create the necessary conversion dashboards in Amplitude, namely:

-An amplitude exploratory event fires when the component is in the viewport. 
-An amplitude exploratory event fires when someone either clicks on the list name (to go to the list), or an article in the list.

Dashboards:
https://analytics.eu.amplitude.com/ftdotcom/chart/e-elc08q8
https://analytics.eu.amplitude.com/ftdotcom/chart/e-lfusk1s

### Ticket
[ug-995](https://financialtimes.atlassian.net/jira/software/c/projects/UG/boards/1128?modal=detail&selectedIssue=UG-995)

### How do I test this code?
1. Clone the branch locally and run `npm link`
2. Run next-article `ug-992-browsable-lists` branch locally and run `npm link @financial-times/n-browsable-lists`
3. load a page, e.g. https://local.ft.com:5050/content/f9d90465-1036-430d-8f54-21d075a7b3ec. In dev tools network tab check that:

- An event is fired when the browsable lists component comes into view, one time per page load
- An event is fired when clicking on the list tile and the list article items
- That each event contains the relevant info, i.e. category, action, list id, concept id.

These should also appear in the amplitude dashboards, if you go on to save an article.
