### PR TITLE
UG-991: Add visible focus indicator to heading link

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -29,10 +29,16 @@ $o-typography-load-fonts: false;
 		color: oColorsByName('claret');
 
 		a {
+			display: block;
 			text-decoration: none;
+
+			&:focus-visible {
+				outline: 2px solid oColorsByName('claret');
+			}
 		}
 
 		&-heading {
+
 			margin-bottom: 0;
 			@include oTypographySans($scale: 0, $weight: 'semibold');
 			color: oColorsByName('claret');


### PR DESCRIPTION
### Description
Adds a strong visible focus indicator to the heading link to allow keyboard users to easily identify their location.
Note: The link had `display: inline` as default, which doesn't work with the `outline` property. I changed it to `display:block` as a workaround. 

### Ticket
[UG-991](https://financialtimes.atlassian.net/browse/UG-991)

### Screenshots

| Before | After |
| ------ | ----- |
|<img width="303" alt="Screenshot 2023-01-05 at 14 55 03" src="https://user-images.githubusercontent.com/7011304/210810658-40af7b5f-72b3-4a81-8751-fc3862653fc7.png">|<img width="304" alt="Screenshot 2023-01-05 at 15 38 48" src="https://user-images.githubusercontent.com/7011304/210820384-1c005726-c074-48cd-bc17-b1731a3c773e.png">|

### How do I test this code?

- Check out this branch and run it locally with `npm run demo`
- Go to the demo page on `https://local.ft.com:5005`
- Press tab until the focus in on the heading link
- A rectangle should indicate that the link has the focus

### Reminder

Have you completed these common tasks? (remove those that don't apply)

- [x] **Manual Testing** checked the expected functionality
- [x] **Guidance for reviewer** communicated expected changes / behaviour, and how reviewers can test it
- [x] **Accessibility** checked for screen readers and contrast


### How we will review this PR
Our team uses [conventional comments](https://conventionalcomments.org/) to provide feedback.


[UG-991]: https://financialtimes.atlassian.net/browse/UG-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ