### PR TITLE
ug-1106 update mappings for professors

### DIFF
--- a/BrowsableListsData.jsx
+++ b/BrowsableListsData.jsx
@@ -7,13 +7,14 @@ import { h } from '@financial-times/x-engine';
 const DATA_EMBED_ID = 'browsable-lists-data'
 
 BrowsableListsData.propTypes = {
-	concepts: PropTypes.array.isRequired
+	concepts: PropTypes.array.isRequired,
+	variant: PropTypes.string.isRequired
 };
 
-export function BrowsableListsData({ concepts }) {
-	if (concepts) {
+export function BrowsableListsData({ concepts, variant}) {
+	if (concepts && variant) {
 		return (
-			<DataEmbed id={DATA_EMBED_ID} data={{ concepts }} />
+			<DataEmbed id={DATA_EMBED_ID} data={{ concepts, variant }} />
 		)
 	}
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This component has been designed as part of the Browsable Lists A/B test. Theref
 
 ## How to use in a consuming app
 
-Import the component and add it to the consumer's markup, passing it a `concepts` prop:
+Import the component and add it to the consumer's markup, passing it `concepts` and `variant` props:
 ```
 import { BrowsableLists } from '@financial-times/n-browsable-lists';
 
 <>
 	...
-	<BrowsableLists concepts={concepts} />
+	<BrowsableLists concepts={concepts} variant={variant} />
 	...
 </>
 ```

--- a/concept-list-map.js
+++ b/concept-list-map.js
@@ -1,6 +1,6 @@
 export const sources = {
-	EDITORIAL: 'editorial',
-	PROFESSOR: 'university professor'
+	EDITORIAL: 'editor',
+	PROFESSOR: 'professor'
 };
 
 const covidList = {
@@ -33,215 +33,266 @@ const usInflationList = {
 	source: sources.EDITORIAL
 };
 
-const lifeArtsList = {
-	id: 'e90439da-a541-4c14-88c8-707fcea6d84e',
-	source: sources.EDITORIAL
+const ftxList = {
+	id: '53b9544a-9aba-43e8-9c3a-f389ec1420a0',
+	source: sources.PROFESSOR
+};
+
+const usMercantList = {
+	id: '3b0e2e3e-63ce-4aaf-94be-d5bc779a3b23',
+	source: sources.PROFESSOR
+};
+
+const finTechList = {
+	id: 'b89ac3a1-5287-4052-a731-8383108e2e50',
+	source: sources.PROFESSOR
+};
+
+const bankingUnionList = {
+	id: '56c9c3a6-e4a1-4d11-8b11-40b8f76fea2e',
+	source: sources.PROFESSOR
+};
+
+const hrmList = {
+	id: '8639abe7-d18d-41eb-b43c-7aa5173f4047',
+	source: sources.PROFESSOR
+};
+
+const lawList = {
+	id: '69a63b22-25db-470e-af97-ad7bc21d6c55',
+	source: sources.PROFESSOR
+};
+
+const chinaList = {
+	id: '5982a6b3-20b2-4f31-a135-c40744113de3',
+	source: sources.PROFESSOR
+};
+
+const gsList = {
+	id: '12f5f315-59d7-4655-b6b7-37a971a1194a',
+	source: sources.PROFESSOR
+};
+
+const globalStrategyList = {
+	id: '8e056408-bc06-4976-b084-0970ceaf4164',
+	source: sources.PROFESSOR
+};
+
+const priceMechanismList = {
+	id: 'a655a110-d88d-459b-9b27-06cfe74804ee',
+	source: sources.PROFESSOR
+};
+
+const concepts = {
+	coronavirusPandemic: {
+		id: '87e110e6-2170-408b-b267-d3b6bdbfeaa3'
+	},
+	energySector: {
+		id: '5216ff2e-a6ed-42b2-a613-109fc6491ba2'
+	},
+	globalEconomy: {
+		id: '29e67a92-a3b8-410c-9139-15abe9b47e12'
+	},
+	foodSecurity: {
+		id: '9ab8e36c-4b79-4e96-9aae-cc586b7d19c4'
+	},
+	technologySector: {
+		id: '6b32f2c1-da43-4e19-80b9-8aef4ab640d7'
+	},
+	usCanadianCompanies: {
+		id: '1248b3d3-1d4c-4454-af23-c0b4707ed412'
+	},
+	mergersAquisitions: {
+		id: '9d13b836-df76-4445-b599-10ae378680f0'
+	},
+	cryptoFinance: {
+		id: '6c503953-7ee0-45d7-b316-f7834be9ff90'
+	},
+	financialMarketsRegulation: {
+		id: 'baf2d326-7e13-4309-9f87-3eb1708468ff'
+	},
+	bitcoin: {
+		id: 'a072c32f-42de-4cc6-8e77-c468d681e5db'
+	},
+	nonFungibleTokens: {
+		id: '72709ae9-1963-4d08-a153-8a5746accb20'
+	},
+	investments: {
+		id: '56f3a4f4-2a28-4a03-8bcc-cabf82c4015b'
+	},
+	usPoliticsPolicy: {
+		id: '6f7d5d90-ac15-41fe-9e31-e69b42a013c6'
+	},
+	oilGasIndustry: {
+		id: '9f991f8b-1d17-4d99-82f4-0cd8fe50b59b'
+	},
+	usBanks: {
+		id: '456d01ad-ea50-4aa7-8d7f-b9737216d453'
+	},
+	usEconomy: {
+		id: '6aa143a2-7a0c-4a20-ae90-ca0a46f36f92'
+	}
 };
 
 export const conceptListMap = [
 	{
-		conceptId: '48256173-6393-4d0e-9364-19a52aef5df1',
+		conceptId: concepts.coronavirusPandemic.id,
 		listId: covidList.id,
 		source: covidList.source
 	},
 	{
-		conceptId: 'f1a6c14e-1fb0-4f7f-83a0-552276dc6cfb',
-		listId: covidList.id,
-		source: covidList.source
+		conceptId: concepts.coronavirusPandemic.id,
+		listId: chinaList.id,
+		source: chinaList.source
 	},
 	{
-		conceptId: '87e110e6-2170-408b-b267-d3b6bdbfeaa3',
-		listId: covidList.id,
-		source: covidList.source
-	},
-	{
-		conceptId: '8b9c78a1-2a6d-4e2f-9293-49f399f4f6ce',
+		conceptId: concepts.energySector.id,
 		listId: ukraineList.id,
 		source: ukraineList.source
 	},
 	{
-		conceptId: 'db09717e-0073-4283-93a1-c2f0c0d8a4dc',
+		conceptId: concepts.energySector.id,
+		listId: priceMechanismList.id,
+		source: priceMechanismList.source
+	},
+	{
+		conceptId: concepts.globalEconomy.id,
 		listId: ukraineList.id,
 		source: ukraineList.source
 	},
 	{
-		conceptId: '573cc1d3-b359-4548-a69a-4aa0b3818c1b',
+		conceptId: concepts.globalEconomy.id,
+		listId: bankingUnionList.id,
+		source: bankingUnionList.source
+	},
+	{
+		conceptId: concepts.foodSecurity.id,
 		listId: ukraineList.id,
 		source: ukraineList.source
 	},
 	{
-		conceptId: 'f25f84dd-a570-468f-b370-e314e96fc319',
-		listId: ukraineList.id,
-		source: ukraineList.source
+		conceptId: concepts.foodSecurity.id,
+		listId: chinaList.id,
+		source: chinaList.source
 	},
 	{
-		conceptId: '5216ff2e-a6ed-42b2-a613-109fc6491ba2',
-		listId: ukraineList.id,
-		source: ukraineList.source
-	},
-	{
-		conceptId: '68678217-1d06-4600-9d43-b0e71a333c2a',
-		listId: ukraineList.id,
-		source: ukraineList.source
-	},
-	{
-		conceptId: '29e67a92-a3b8-410c-9139-15abe9b47e12',
-		listId: ukraineList.id,
-		source: ukraineList.source
-	},
-	{
-		conceptId: '9ab8e36c-4b79-4e96-9aae-cc586b7d19c4',
-		listId: ukraineList.id,
-		source: ukraineList.source
-	},
-	{
-		conceptId: 'a54ba68e-4aa3-4aa0-8a11-61456f4dfaa1',
+		conceptId: concepts.technologySector.id,
 		listId: twitterList.id,
 		source: twitterList.source
 	},
 	{
-		conceptId: '6b32f2c1-da43-4e19-80b9-8aef4ab640d7',
+		conceptId: concepts.technologySector.id,
+		listId: hrmList.id,
+		source: hrmList.source
+	},
+	{
+		conceptId: concepts.usCanadianCompanies.id,
 		listId: twitterList.id,
 		source: twitterList.source
 	},
 	{
-		conceptId: 'fdf71598-69ee-4801-a704-df53f01ef286',
+		conceptId: concepts.usCanadianCompanies.id,
+		listId: finTechList.id,
+		source: finTechList.source
+	},
+	{
+		conceptId: concepts.mergersAquisitions.id,
 		listId: twitterList.id,
 		source: twitterList.source
 	},
 	{
-		conceptId: '03711791-2306-46a4-a5f5-1d79e57bd21d',
-		listId: twitterList.id,
-		source: twitterList.source
+		conceptId: concepts.mergersAquisitions.id,
+		listId: lawList.id,
+		source: lawList.source
 	},
 	{
-		conceptId: '1248b3d3-1d4c-4454-af23-c0b4707ed412',
-		listId: twitterList.id,
-		source: twitterList.source
-	},
-	{
-		conceptId: '9d13b836-df76-4445-b599-10ae378680f0',
-		listId: twitterList.id,
-		source: twitterList.source
-	},
-	{
-		conceptId: '6c503953-7ee0-45d7-b316-f7834be9ff90',
+		conceptId: concepts.cryptoFinance.id,
 		listId: cryptoList.id,
 		source: cryptoList.source
 	},
 	{
-		conceptId: 'baf2d326-7e13-4309-9f87-3eb1708468ff',
+		conceptId: concepts.cryptoFinance.id,
+		listId: ftxList.id,
+		source: ftxList.source
+	},
+	{
+		conceptId: concepts.financialMarketsRegulation.id,
 		listId: cryptoList.id,
 		source: cryptoList.source
 	},
 	{
-		conceptId: 'fb8cdc23-cd37-41b2-abe1-c4dd1fc334af',
+		conceptId: concepts.financialMarketsRegulation.id,
+		listId: finTechList.id,
+		source: finTechList.source
+	},
+	{
+		conceptId: concepts.bitcoin.id,
 		listId: cryptoList.id,
 		source: cryptoList.source
 	},
 	{
-		conceptId: 'a072c32f-42de-4cc6-8e77-c468d681e5db',
+		conceptId: concepts.bitcoin.id,
+		listId: ftxList.id,
+		source: ftxList.source
+	},
+	{
+		conceptId: concepts.nonFungibleTokens.id,
 		listId: cryptoList.id,
 		source: cryptoList.source
 	},
 	{
-		conceptId: '72709ae9-1963-4d08-a153-8a5746accb20',
+		conceptId: concepts.nonFungibleTokens.id,
+		listId: finTechList.id,
+		source: finTechList.source
+	},
+	{
+		conceptId: concepts.investments.id,
 		listId: cryptoList.id,
 		source: cryptoList.source
 	},
 	{
-		conceptId: '64cf47f4-3f23-4d52-9c88-c11575e57749',
-		listId: cryptoList.id,
-		source: cryptoList.source
+		conceptId: concepts.investments.id,
+		listId: globalStrategyList.id,
+		source: globalStrategyList.source
 	},
 	{
-		conceptId: '56f3a4f4-2a28-4a03-8bcc-cabf82c4015b',
-		listId: cryptoList.id,
-		source: cryptoList.source
-	},
-	{
-		conceptId: 'e191658e-c66a-45bc-9bad-343bdc4210b3',
+		conceptId: concepts.usPoliticsPolicy.id,
 		listId: usPoliticsList.id,
 		source: usPoliticsList.source
 	},
 	{
-		conceptId: 'eeb704cf-70f9-4bab-a630-576ce68a9aab',
+		conceptId: concepts.usPoliticsPolicy.id,
+		listId: gsList.id,
+		source: gsList.source
+	},
+	{
+		conceptId: concepts.oilGasIndustry.id,
 		listId: usPoliticsList.id,
 		source: usPoliticsList.source
 	},
 	{
-		conceptId: '6f7d5d90-ac15-41fe-9e31-e69b42a013c6',
-		listId: usPoliticsList.id,
-		source: usPoliticsList.source
+		conceptId: concepts.oilGasIndustry.id,
+		listId: lawList.id,
+		source: lawList.source
 	},
 	{
-		conceptId: '9f991f8b-1d17-4d99-82f4-0cd8fe50b59b',
-		listId: usPoliticsList.id,
-		source: usPoliticsList.source
-	},
-	{
-		conceptId: '7982616a-e179-45f1-86f6-948f1fc35523',
+		conceptId: concepts.usBanks.id,
 		listId: usInflationList.id,
 		source: usInflationList.source
 	},
 	{
-		conceptId: '9ebb1f73-1eed-4031-9c5e-bc56800abba7',
+		conceptId: concepts.usBanks.id,
+		listId: globalStrategyList.id,
+		source: globalStrategyList.source
+	},
+	{
+		conceptId: concepts.usEconomy.id,
 		listId: usInflationList.id,
 		source: usInflationList.source
 	},
 	{
-		conceptId: '456d01ad-ea50-4aa7-8d7f-b9737216d453',
-		listId: usInflationList.id,
-		source: usInflationList.source
-	},
-	{
-		conceptId: '6aa143a2-7a0c-4a20-ae90-ca0a46f36f92',
-		listId: usInflationList.id,
-		source: usInflationList.source
-	},
-	{
-		conceptId: '9577c6d4-b09e-4552-b88f-e52745abe02b',
-		listId: usInflationList.id,
-		source: usInflationList.source
-	},
-	{
-		conceptId: 'e5533208-e5cc-4be5-aea1-c464a9a205e3',
-		listId: usInflationList.id,
-		source: usInflationList.source
-	},
-	{
-		conceptId: '3e2eb1c1-7ecd-4600-8cbb-c02ba53ced4b',
-		listId: usInflationList.id,
-		source: usInflationList.source
-	},
-	{
-		conceptId: '0b83bc44-4a55-4958-882e-73ba6b2b0aa6',
-		listId: lifeArtsList.id,
-		source: lifeArtsList.source
-	},
-	{
-		conceptId: 'f9f7535d-3b5c-47a7-bd15-3e10dceee597',
-		listId: lifeArtsList.id,
-		source: lifeArtsList.source
-	},
-	{
-		conceptId: 'bf588a1d-44e1-495c-93f5-a98e1e3aa8d8',
-		listId: lifeArtsList.id,
-		source: lifeArtsList.source
-	},
-	{
-		conceptId: '02d551a4-94a6-4783-8ea9-8aa982cb1225',
-		listId: lifeArtsList.id,
-		source: lifeArtsList.source
-	},
-	{
-		conceptId: '6c94a300-579e-43d0-8536-b2ae05bb6ff4',
-		listId: lifeArtsList.id,
-		source: lifeArtsList.source
-	},
-	{
-		conceptId: '0d5b6eb9-7512-4db2-ae4a-b9d4e0da548a',
-		listId: lifeArtsList.id,
-		source: lifeArtsList.source
+		conceptId: concepts.usEconomy.id,
+		listId: usMercantList.id,
+		source: usMercantList.source
 	}
 ];

--- a/demos/app.js
+++ b/demos/app.js
@@ -12,12 +12,14 @@ app.set('view engine', 'html');
 const renderer = new PageKitReactJSX();
 app.engine('jsx', renderer.engine);
 
-app.get('/:conceptId?', (req, res) => {
-	const { conceptId } = req.params;
+app.get('/:conceptId?/:variant?', (req, res) => {
+	const { conceptId, variant } = req.params;
+
 	return res.render('main.jsx', {
 		layout: 'custom-vanilla',
 		title: 'Demo',
-		conceptId
+		conceptId,
+		variant
 	});
 });
 

--- a/demos/templates/main.jsx
+++ b/demos/templates/main.jsx
@@ -3,29 +3,31 @@ import { Shell } from '@financial-times/dotcom-ui-shell';
 import PropTypes from 'prop-types';
 import { BrowsableLists } from '../../';
 
-const DEFAULT_CONCEPT = '48256173-6393-4d0e-9364-19a52aef5df1'
+const DEFAULT_CONCEPT = 'a072c32f-42de-4cc6-8e77-c468d681e5db'
+const DEFAULT_VARIANT = 'editor'
 
 MainTemplate.propTypes = {
 	conceptId: PropTypes.string,
+	variant: PropTypes.string
 };
 
-export default function MainTemplate({ conceptId = DEFAULT_CONCEPT }) {
+export default function MainTemplate({ conceptId = DEFAULT_CONCEPT, variant = DEFAULT_VARIANT }) {
 	const concepts = [
 		conceptId
 	]
 
 	return (
 		<Shell siteTitle={`Browsable lists demo`}>
-			<link rel="stylesheet" href="./public/styles.css"/>
+			<link rel="stylesheet" href="../public/styles.css"/>
 			<main>
 				<div className='content'>
 					<h1 className="demo-header">Browsable lists component</h1>
 				</div>
 				<aside className='rhr'>
-					<BrowsableLists concepts={concepts} />
+					<BrowsableLists concepts={concepts} variant={variant} />
 				</aside>
 			</main>
-			<script src="./public/bundle.js"></script>
+			<script src="../public/bundle.js"></script>
 		</Shell>
 	)
 }

--- a/main.js
+++ b/main.js
@@ -86,14 +86,16 @@ function addClickTrackingHandlers() {
 export async function init({ parentSelector }) {
 	const dataEmbedClient = dataEmbed.init({ id: 'browsable-lists-data' });
 
-	const concepts = dataEmbedClient.get('concepts');
+	const { variant, concepts } = dataEmbedClient.getAll();
 	const container = document.querySelector(parentSelector);
 
-	if (container && concepts) {
+	if (container && concepts && variant) {
 		matchedList =
 			Array.isArray(concepts) &&
 			conceptListMap.find((pair) =>
-				concepts.find((concept) => concept === pair.conceptId)
+				concepts.find(
+					(concept) => concept === pair.conceptId && variant === pair.source
+				)
 			);
 
 		const listId = matchedList?.listId;


### PR DESCRIPTION
### Description
This PR 

- adds selected professor lists to the component
- adds the logic to deliver either professor or editorial lists based on the variant assigned in ammit.
- updates demo

### Ticket
[ug-1106](https://financialtimes.atlassian.net/browse/UG-1106)

### Screenshots

Editorial/before
<img width="909" alt="Screenshot 2023-01-09 at 11 22 39" src="https://user-images.githubusercontent.com/54366961/211297443-a618311c-a064-4368-9203-d24509c18a23.png">

Professor
<img width="915" alt="Screenshot 2023-01-09 at 11 21 53" src="https://user-images.githubusercontent.com/54366961/211297505-a7461eab-b196-4420-bebf-8b7dc4d0043a.png">

### How do I test this code?

1. Check out the branch locally, run `npm install` and `npm run build`
2. Run `npm run demo` and open https://local.ft.com:5005/ - you should see the component
3. Add various concepts included in the concept map to the path, and both "professor" and "editor" for each, i.e. https://local.ft.com:5005/<conceptId>/<variant>, and see the list and copy change appropriately. E.g. https://local.ft.com:5005/6b32f2c1-da43-4e19-80b9-8aef4ab640d7/editor and https://local.ft.com:5005/6b32f2c1-da43-4e19-80b9-8aef4ab640d7/professor
4. Try passing in a fake conceptId or variant - the page should load with no component 
