### PR TITLE
Send exposure event to amplitude experiment API

### DIFF
--- a/demos/app.js
+++ b/demos/app.js
@@ -14,11 +14,13 @@ app.engine('jsx', renderer.engine);
 
 app.get('/:conceptId?/:variant?', (req, res) => {
 	const { conceptId, variant } = req.params;
+	const amplitudeExperiment = req.query;
 
 	return res.render('main.jsx', {
 		layout: 'custom-vanilla',
 		title: 'Demo',
 		conceptId,
+		amplitudeExperiment: !!amplitudeExperiment,
 		variant
 	});
 });

--- a/demos/app.js
+++ b/demos/app.js
@@ -14,7 +14,7 @@ app.engine('jsx', renderer.engine);
 
 app.get('/:conceptId?/:variant?', (req, res) => {
 	const { conceptId, variant } = req.params;
-	const amplitudeExperiment = req.query;
+	const amplitudeExperiment = req.query.amplitudeExperiment;
 
 	return res.render('main.jsx', {
 		layout: 'custom-vanilla',

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -10,6 +10,6 @@ oTracking.init({
 
 oTracking.click.init('cta');
 
-browsableListsInit({
-	parentSelector: '.rhr'
-});
+const demoVars = document.getElementById('demo-vars');
+const { amplitudeExperiment } = JSON.parse(demoVars.textContent);
+browsableListsInit({ amplitudeExperiment, parentSelector: '.rhr' });

--- a/demos/templates/main.jsx
+++ b/demos/templates/main.jsx
@@ -12,7 +12,7 @@ MainTemplate.propTypes = {
 	amplitudeExperiment: PropTypes.bool,
 };
 
-export default function MainTemplate({ conceptId = DEFAULT_CONCEPT, variant = DEFAULT_VARIANT, amplitudeExperiment = true }) {
+export default function MainTemplate({ conceptId = DEFAULT_CONCEPT, variant = DEFAULT_VARIANT, amplitudeExperiment }) {
 	const concepts = [
 		conceptId
 	]

--- a/demos/templates/main.jsx
+++ b/demos/templates/main.jsx
@@ -8,10 +8,11 @@ const DEFAULT_VARIANT = 'editor'
 
 MainTemplate.propTypes = {
 	conceptId: PropTypes.string,
-	variant: PropTypes.string
+	variant: PropTypes.string,
+	amplitudeExperiment: PropTypes.bool,
 };
 
-export default function MainTemplate({ conceptId = DEFAULT_CONCEPT, variant = DEFAULT_VARIANT }) {
+export default function MainTemplate({ conceptId = DEFAULT_CONCEPT, variant = DEFAULT_VARIANT, amplitudeExperiment = true }) {
 	const concepts = [
 		conceptId
 	]
@@ -27,6 +28,7 @@ export default function MainTemplate({ conceptId = DEFAULT_CONCEPT, variant = DE
 					<BrowsableLists concepts={concepts} variant={variant} />
 				</aside>
 			</main>
+			<script type='application/json' id='demo-vars' dangerouslySetInnerHTML={{ __html: JSON.stringify({ amplitudeExperiment }) }} />
 			<script src="../public/bundle.js"></script>
 		</Shell>
 	)

--- a/main.js
+++ b/main.js
@@ -126,7 +126,7 @@ function dispatchAmplitudeExperimentExposureEvent(variant) {
 	});
 }
 
-export async function init({ parentSelector, amplitudeExploratory }) {
+export async function init({ parentSelector, amplitudeExperiment }) {
 	const dataEmbedClient = dataEmbed.init({ id: 'browsable-lists-data' });
 
 	const { variant, concepts } = dataEmbedClient.getAll();
@@ -161,7 +161,7 @@ export async function init({ parentSelector, amplitudeExploratory }) {
 			);
 
 			contentContainer = document.querySelector('.browsable-lists');
-			if (amplitudeExploratory) {
+			if (amplitudeExperiment) {
 				dispatchAmplitudeExperimentExposureEvent(variant);
 			}
 			dispatchTrackingEvent('component-mount');

--- a/main.js
+++ b/main.js
@@ -8,6 +8,9 @@ import { BrowsableListsContent } from './BrowsableListsContent.jsx';
 // eslint-disable-next-line no-unused-vars
 import { h, render } from '@financial-times/x-engine';
 
+const AMPLITUDE_ANALYTICS_KEY = '71c1f5ad2620abae054c4b729fe1d22e';
+const AMPLITUDE_API_URL = 'https://api.eu.amplitude.com/2/httpapi';
+
 let viewed = false;
 let contentContainer;
 let matchedList;
@@ -83,7 +86,47 @@ function addClickTrackingHandlers() {
 	}
 }
 
-export async function init({ parentSelector }) {
+function getCookieByName(name) {
+	const cookies = document.cookie.split(';');
+
+	const cookie = cookies
+		.map((cookie) => cookie.trim())
+		.find((cookie) => cookie.startsWith(name + '='));
+
+	return cookie ? cookie.substring(name.length + 1) : null;
+}
+
+function dispatchAmplitudeExperimentExposureEvent(variant) {
+	const userId = getCookieByName('FTAllocation');
+	const deviceId = getCookieByName('spoor-id');
+
+	if (!userId && !deviceId) {
+		return;
+	}
+
+	return fetch(AMPLITUDE_API_URL, {
+		method: 'POST',
+		body: JSON.stringify({
+			api_key: AMPLITUDE_ANALYTICS_KEY,
+			events: [
+				{
+					event_type: '$exposure',
+					user_id: userId,
+					device_id: deviceId,
+					event_properties: {
+						flag_key: 'browsable-lists',
+						variant
+					}
+				}
+			]
+		})
+	}).catch(() => {
+		// In the future, we can send this error to Sentry
+		// or look if there's any monitoring available on Amplitude
+	});
+}
+
+export async function init({ parentSelector, amplitudeExploratory }) {
 	const dataEmbedClient = dataEmbed.init({ id: 'browsable-lists-data' });
 
 	const { variant, concepts } = dataEmbedClient.getAll();
@@ -118,7 +161,9 @@ export async function init({ parentSelector }) {
 			);
 
 			contentContainer = document.querySelector('.browsable-lists');
-
+			if (amplitudeExploratory) {
+				dispatchAmplitudeExperimentExposureEvent(variant);
+			}
 			dispatchTrackingEvent('component-mount');
 			addInViewTrackingHandler();
 			addClickTrackingHandlers();

--- a/main.js
+++ b/main.js
@@ -120,10 +120,17 @@ function dispatchAmplitudeExperimentExposureEvent(variant) {
 				}
 			]
 		})
-	}).catch(() => {
-		// In the future, we can send this error to Sentry
-		// or look if there's any monitoring available on Amplitude
-	});
+	})
+		.then((response) => {
+			if (!response.ok) {
+				throw new Error(`Request failed status: ${response.status}`);
+			}
+		})
+		.catch((error) => {
+			// In the future, we can send this error to Sentry
+			// or look if there's any monitoring available on Amplitude
+			console.error(error); // eslint-disable-line no-console
+		});
 }
 
 export async function init({ parentSelector, amplitudeExperiment }) {


### PR DESCRIPTION
### Description
We need to send an[ exposure event](https://www.docs.developers.amplitude.com/experiment/general/exposure-tracking/#exposure-event) to Amplitude Experiment API after a user has been exposed to variant of the browsable-lists component

### Ticket
https://financialtimes.atlassian.net/browse/UG-1287

### How do I test this code?
check out this branch locally
run the demo page `npm run demo` and visit https://local.ft.com:5005
add the query parameter to the URL e.g https://local.ft.com:5005/?amplitudeExperiment=true&variant=variant
ensure that the POST request is being sent successfully you should see `httpapi` on the network tab

### Reminder
Have you completed these common tasks? (remove those that don't apply)

- [x] **Documentation** updated or created
- [x] **Manual Testing** checked the expected functionality
- [x] **Guidance for reviewer** communicated expected changes / behaviour, and how reviewers can test it




### How we will review this PR
Our team uses [conventional comments](https://conventionalcomments.org/) to provide feedback.
