### PR TITLE
UG-1216 remove outdated concepts from browsable lists

### DIFF
--- a/concept-list-map.js
+++ b/concept-list-map.js
@@ -86,6 +86,15 @@ const concepts = {
 	foodSecurity: {
 		id: '9ab8e36c-4b79-4e96-9aae-cc586b7d19c4'
 	},
+	technologySector: {
+		id: '6b32f2c1-da43-4e19-80b9-8aef4ab640d7'
+	},
+	usCanadianCompanies: {
+		id: '1248b3d3-1d4c-4454-af23-c0b4707ed412'
+	},
+	mergersAquisitions: {
+		id: '9d13b836-df76-4445-b599-10ae378680f0'
+	},
 	cryptoFinance: {
 		id: '6c503953-7ee0-45d7-b316-f7834be9ff90'
 	},

--- a/concept-list-map.js
+++ b/concept-list-map.js
@@ -13,11 +13,6 @@ const ukraineList = {
 	source: sources.EDITORIAL
 };
 
-const twitterList = {
-	id: '8a295234-041e-4924-a73d-effd317bd737',
-	source: sources.EDITORIAL
-};
-
 const cryptoList = {
 	id: '44a24834-eae9-4fe4-9eeb-b28c511579b1',
 	source: sources.EDITORIAL
@@ -50,11 +45,6 @@ const finTechList = {
 
 const bankingUnionList = {
 	id: '56c9c3a6-e4a1-4d11-8b11-40b8f76fea2e',
-	source: sources.PROFESSOR
-};
-
-const hrmList = {
-	id: '8639abe7-d18d-41eb-b43c-7aa5173f4047',
 	source: sources.PROFESSOR
 };
 
@@ -95,15 +85,6 @@ const concepts = {
 	},
 	foodSecurity: {
 		id: '9ab8e36c-4b79-4e96-9aae-cc586b7d19c4'
-	},
-	technologySector: {
-		id: '6b32f2c1-da43-4e19-80b9-8aef4ab640d7'
-	},
-	usCanadianCompanies: {
-		id: '1248b3d3-1d4c-4454-af23-c0b4707ed412'
-	},
-	mergersAquisitions: {
-		id: '9d13b836-df76-4445-b599-10ae378680f0'
 	},
 	cryptoFinance: {
 		id: '6c503953-7ee0-45d7-b316-f7834be9ff90'
@@ -174,36 +155,6 @@ export const conceptListMap = [
 		conceptId: concepts.foodSecurity.id,
 		listId: chinaList.id,
 		source: chinaList.source
-	},
-	{
-		conceptId: concepts.technologySector.id,
-		listId: twitterList.id,
-		source: twitterList.source
-	},
-	{
-		conceptId: concepts.technologySector.id,
-		listId: hrmList.id,
-		source: hrmList.source
-	},
-	{
-		conceptId: concepts.usCanadianCompanies.id,
-		listId: twitterList.id,
-		source: twitterList.source
-	},
-	{
-		conceptId: concepts.usCanadianCompanies.id,
-		listId: finTechList.id,
-		source: finTechList.source
-	},
-	{
-		conceptId: concepts.mergersAquisitions.id,
-		listId: twitterList.id,
-		source: twitterList.source
-	},
-	{
-		conceptId: concepts.mergersAquisitions.id,
-		listId: lawList.id,
-		source: lawList.source
 	},
 	{
 		conceptId: concepts.cryptoFinance.id,


### PR DESCRIPTION
### Description
Remove outdated concepts map from Browsable Lists

### Ticket
https://financialtimes.atlassian.net/browse/UG-1295

### How do I test this code?
1. Check out this branch locally and run `npm install` and then `npm link`
2. In a new terminal cd or clone into `next-article` and run `npm link @financial-times/n-browsable-lists`
3. Run next-article by running `npm start`
4. visit https://local.ft.com:5050/
5. Add the `next-flags` cookie using your browser's dev tools. 
6. The value of the flag should be `amplitude_browsable-lists:editor` or `amplitude_browsable-lists:professor` 
7. and the domain should be `.ft.com`.
8. click on an article in any of these concepts [technologySector](https://local.ft.com:5050/stream/6b32f2c1-da43-4e19-80b9-8aef4ab640d7), [usCanadianCompanies](https://local.ft.com:5050/stream/1248b3d3-1d4c-4454-af23-c0b4707ed412), [mergersAquisitions](https://local.ft.com:5050/stream/9d13b836-df76-4445-b599-10ae378680f0)
9. ensure that you are getting the `amplitude-browsable-lists` flag which can be found by expanding the `page-kit-flags-embed` script tag in the elements tab in the dev tools
10. confirm that the browsable-lists component is ***not*** visible on any articles within the concepts above
11. finally confirm that the browsable-lists component **_is_** visible on an article within a concept that hasn't been removed e.g [this article](https://local.ft.com:5050/content/7ea4fca0-dec9-455a-8ce2-d7e6b1b56ba2)

### Reminder
Have you completed these common tasks? (remove those that don't apply)

- [x] **Documentation** updated or created
- [x] **Manual Testing** checked the expected functionality
- [x] **Guidance for reviewer** communicated expected changes / behaviour, and how reviewers can test it

### How we will review this PR
Our team uses [conventional comments](https://conventionalcomments.org/) to provide feedback.
